### PR TITLE
Feat binlog retention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+# This GitHub action can publish assets for release when a tag is created.
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+#
+# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
+# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
+# secret. If you would rather own your own GPG handling, please fork this action
+# or use an alternative one for key handling.
+#
+# You will need to pass the `--batch` flag to `gpg` in your signing step 
+# in `goreleaser` to indicate this is being used in a non-interactive mode.
+#
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+permissions:
+  contents: write
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      -
+        name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4.1.0
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          # GitHub sets this automatically
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -141,14 +141,15 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"mysql_database":        resourceDatabase(),
-			"mysql_global_variable": resourceGlobalVariable(),
-			"mysql_grant":           resourceGrant(),
-			"mysql_role":            resourceRole(),
-			"mysql_sql":             resourceSql(),
-			"mysql_user_password":   resourceUserPassword(),
-			"mysql_user":            resourceUser(),
-			"mysql_ti_config":       resourceTiConfigVariable(),
+			"mysql_database":         resourceDatabase(),
+			"mysql_global_variable":  resourceGlobalVariable(),
+			"mysql_grant":            resourceGrant(),
+			"mysql_role":             resourceRole(),
+			"mysql_sql":              resourceSql(),
+			"mysql_user_password":    resourceUserPassword(),
+			"mysql_user":             resourceUser(),
+			"mysql_ti_config":        resourceTiConfigVariable(),
+			"mysql_binlog_retention": resourceBinLog(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/mysql/resource_binlog.go
+++ b/mysql/resource_binlog.go
@@ -1,0 +1,129 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBinLog() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: CreateBinLog,
+		UpdateContext: UpdateBinLog,
+		ReadContext:   ReadBinLog,
+		DeleteContext: DeleteBinLog,
+		Importer: &schema.ResourceImporter{
+			StateContext: ImportDatabase,
+		},
+		Schema: map[string]*schema.Schema{
+			"retention_period": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "NULL",
+			},
+		},
+	}
+}
+
+func CreateBinLog(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	stmtSQL := binlogConfigSQL(d)
+	log.Println("Executing statement:", stmtSQL)
+
+	_, err = db.ExecContext(ctx, stmtSQL)
+	if err != nil {
+		return diag.Errorf("failed running SQL to set binlog retention period: %v", err)
+	}
+
+	d.SetId(d.Get("retention_period").(string))
+
+	return ReadBinLog(ctx, d, meta)
+}
+
+func UpdateBinLog(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	stmtSQL := binlogConfigSQL(d)
+	log.Println("Executing statement:", stmtSQL)
+
+	_, err = db.ExecContext(ctx, stmtSQL)
+	if err != nil {
+		return diag.Errorf("failed updating binlog retention period: %v", err)
+	}
+
+	return ReadBinLog(ctx, d, meta)
+}
+
+func ReadBinLog(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	stmtSQL := "call mysql.rds_show_configuration"
+
+	log.Println("Executing query:", stmtSQL)
+	rows, err := db.QueryContext(ctx, stmtSQL)
+	if err != nil {
+		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
+			if mysqlErr.Number == unknownDatabaseErrCode {
+				d.SetId("")
+				return nil
+			}
+		}
+		return diag.Errorf("Error verifying binlog retention period: %s", err)
+	}
+
+	results := make(map[string]string)
+	for rows.Next() {
+		var name, value, description string
+
+		if err := rows.Scan(&name, &value, &description); err != nil {
+			return diag.Errorf("failed reading binlog retention period: %v", err)
+		}
+		results[name] = value
+	}
+
+	d.Set("retention_period", results["binlog retention hours"])
+
+	return nil
+}
+
+func DeleteBinLog(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	stmtSQL := "call mysql.rds_set_configuration('binlog retention hours', NULL)"
+	log.Println("Executing statement:", stmtSQL)
+
+	_, err = db.ExecContext(ctx, stmtSQL)
+	if err != nil {
+		return diag.Errorf("failed unsetting binlog retention period: %v", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func binlogConfigSQL(d *schema.ResourceData) string {
+	retention_period := d.Get("retention_period").(string)
+
+	return fmt.Sprintf(
+		"call mysql.rds_set_configuration('binlog retention hours', %s)",
+		retention_period,
+	)
+}

--- a/mysql/resource_binlog.go
+++ b/mysql/resource_binlog.go
@@ -130,15 +130,11 @@ func DeleteBinLog(ctx context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func binlogConfigSQL(d *schema.ResourceData) string {
-	retention_period := d.Get("retention_period")
-	if retention_period == 0 {
-		return fmt.Sprintf(
-			"call mysql.rds_set_configuration('binlog retention hours', %s)",
-			"NULL")
-	} else {
-		return fmt.Sprintf(
-			"call mysql.rds_set_configuration('binlog retention hours', %d)",
-			retention_period,
-		)
+	retention_period := strconv.Itoa(d.Get("retention_period").(int))
+	if retention_period == "0" {
+		retention_period = "NULL"
 	}
+	return fmt.Sprintf(
+		"call mysql.rds_set_configuration('binlog retention hours', %s)",
+		retention_period)
 }


### PR DESCRIPTION
This is part of the [RDS module overhaul](https://giphypedia.atlassian.net/wiki/spaces/~5c2c1b25ccec3834a866c836/pages/3388408241/WIP+RDS+Module+Overhaul) . It tries to solve the unsupported `binlog retention` from mysql terraform provider. Currently, RDS module uses a local exec, which could be replaced by:
```
resource "mysql_binlog_retention" "this" {
  retention_period = 48
}
```

To disable binlog retention:
```
resource "mysql_binlog_retention" "this" {
  retention_period = 0
}
```
Or just destroy the resource.
